### PR TITLE
Geocoding with Rails Admin Map Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Rails Admin Map Field
 
 rails_admin_map_field is a gem that works with sferik's **rails_admin** (https://github.com/sferik/rails_admin) to provide an easy to use Google Maps interface for displaying and setting geographic co-ordinates in a model.
 
-Where a latitude and longitude is set on the model, it is indicated by a marker shown on a Google map centered at the marker. The administrator can change the value of these fields by clicking on the desired new location on the map.
+Where a latitude and longitude is set on the model, it is indicated by a marker shown on a Google map centered at the marker. The administrator is expected to also store address, city, and state fields.  As these fields are filled in, the Maps API is used to geocode the address in order to determine the latitude and longitude of the map marker, which is updated on the fly.
 
 Usage
 =====
@@ -11,7 +11,7 @@ Usage
 rails_admin_map_field expects that the model will have two attributes, one for latitude and one for longitude of the point represented. To enable rails_admin_map_field, add the following to your `Gemfile`:
 
 ```ruby
-gem "rails_admin_map_field", :git => "git://github.com/jasonl/rails_admin_map_field.git"
+gem "rails_admin_map_field", :git => "git://github.com/trademobile/rails_admin_map_field.git"
 ```
 
 Then, add in your `config/initializers/rails_admin.rb` initializer:
@@ -34,6 +34,9 @@ Configuration
 For different configurations, rails_admin_map_field can be configured with the following:
 
 - `longitude_field` - the name of the longitude field that forms the the co-ordinate with the latitude field specified. Defaults to "longitude"
+- `address_field` - the name of the address field. Defaults to "address"
+- `city_field` - the name of the city field. Defaults to "city"
+- `state_field` - the name of the state field. Defaults to "state"
 - `google_api_key` - if you use a Google Maps API Key, it can be specified here.
 - `default_latitude` - the latitude to center the map shown on if the latitude field is blank. Defaults to 51.5, the latitude of London, UK.
 - `default_longitude` - the longitude used if the longitude field is blank. Defaults to -0.126, the longitude of London, UK.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Rails Admin Map Field
 
 rails_admin_map_field is a gem that works with sferik's **rails_admin** (https://github.com/sferik/rails_admin) to provide an easy to use Google Maps interface for displaying and setting geographic co-ordinates in a model.
 
-Where a latitude and longitude is set on the model, it is indicated by a marker shown on a Google map centered at the marker. The administrator can change the value of these fields by clicking on the desired new location on the map.
+Where a latitude and longitude is set on the model, it is indicated by a marker shown on a Google map centered at the marker. The administrator is expected to also store address, city, and state fields.  As these fields are filled in, the Maps API is used to geocode the address in order to determine the latitude and longitude of the map marker, which is updated on the fly.
 
 Usage
 =====
@@ -11,7 +11,7 @@ Usage
 rails_admin_map_field expects that the model will have two attributes, one for latitude and one for longitude of the point represented. To enable rails_admin_map_field, add the following to your `Gemfile`:
 
 ```ruby
-gem "rails_admin_map_field", :git => "git://github.com/jasonl/rails_admin_map_field.git"
+gem "rails_admin_map_field", :git => "git://github.com/trademobile/rails_admin_map_field.git"
 ```
 
 Then, add in your `config/initializers/rails_admin.rb` initializer:
@@ -34,6 +34,9 @@ Configuration
 For different configurations, rails_admin_map_field can be configured with the following:
 
 - `longitude_field` - the name of the longitude field that forms the the co-ordinate with the latitude field specified. Defaults to "longitude"
+- `address_field` - the name of the address field. Defaults to "address"
+- `city_field` - the name of the city field. Defaults to "city"
+- `state_field` - the name of the state field. Defaults to "state"
 - `google_api_key` - if you use a Google Maps API Key, it can be specified here.
 - `default_latitude` - the latitude to center the map shown on if the latitude field is blank. Defaults to 51.5, the latitude of London, UK.
 - `default_longitude` - the longitude used if the longitude field is blank. Defaults to -0.126, the longitude of London, UK.
@@ -59,7 +62,7 @@ LICENSE
 =======
 rails_admin_map_field is licensed under the MIT license.
 
-Copyright (C) 2011 by Jason Langenauer
+Copyright (C) 2011 by Jason Langenauer and Jules Laplace
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -13,6 +13,8 @@
       };
 
       var map = new google.maps.Map(document.getElementById("#{field.dom_name}"), myOptions);
+      var geocoder = new google.maps.Geocoder();
+
 
   - if form.object.send(field.name) && form.object.send(field.longitude_field)
     :plain
@@ -40,7 +42,7 @@
 
         old_address = address_string;
 
-        Science.MapView.geocoder.geocode({ 'address': address_string }, function(results, status){
+        geocoder.geocode({ 'address': address_string }, function(results, status){
           if (! results || results.length === 0 || status !== "OK") return;
           
           var location = results[0].geometry.location;

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -22,9 +22,31 @@
       });
 
   :plain
-      google.maps.event.addListener(map, 'click', function(e) {
-        updateLocation(e.latLng);
-      });
+      var old_address = "";
+      jQuery("##{field.address_dom_name},##{field.city_dom_name},##{field.state_dom_name}").bind("blur", function(){
+        // geocode based on this location
+        var address = $("##{field.address_dom_name}").val(),
+        city = $("##{field.city_dom_name}").val(),
+        state = $("##{field.state_dom_name}").val(),
+        address_string = "",
+        changed = false;
+
+        if (address.length === 0 || city.length === 0 || state.length === 0)
+          return;
+
+        address_string = [address + ",", city, self.get("state"), self.get("zip")].join(" ");
+        if (address_string === old_address)
+          return;
+
+        old_address = address_string;
+
+        Science.MapView.geocoder.geocode({ 'address': address_string }, function(results, status){
+          if (! results || results.length === 0 || status !== "OK") return;
+          
+          var location = results[0].geometry.location;
+          updateLocation(location)
+        });
+      }
 
       function updateLocation(location) {
         if(marker) {

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -13,6 +13,8 @@
       };
 
       var map = new google.maps.Map(document.getElementById("#{field.dom_name}"), myOptions);
+      var geocoder = new google.maps.Geocoder();
+
 
   - if form.object.send(field.name) && form.object.send(field.longitude_field)
     :plain
@@ -34,19 +36,19 @@
         if (address.length === 0 || city.length === 0 || state.length === 0)
           return;
 
-        address_string = [address + ",", city, self.get("state"), self.get("zip")].join(" ");
+        address_string = [address, city, state].join(", ");
         if (address_string === old_address)
           return;
 
         old_address = address_string;
 
-        Science.MapView.geocoder.geocode({ 'address': address_string }, function(results, status){
+        geocoder.geocode({ 'address': address_string }, function(results, status){
           if (! results || results.length === 0 || status !== "OK") return;
           
           var location = results[0].geometry.location;
           updateLocation(location)
         });
-      }
+      });
 
       function updateLocation(location) {
         if(marker) {

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -46,7 +46,7 @@
           var location = results[0].geometry.location;
           updateLocation(location)
         });
-      }
+      });
 
       function updateLocation(location) {
         if(marker) {

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -34,7 +34,7 @@
         if (address.length === 0 || city.length === 0 || state.length === 0)
           return;
 
-        address_string = [address + ",", city, self.get("state"), self.get("zip")].join(" ");
+        address_string = [address, city, state].join(", ");
         if (address_string === old_address)
           return;
 

--- a/gem.gemspec
+++ b/gem.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
 
   s.name              = "rails_admin_map_field"
-  s.version           = "0.0.1"
+  s.version           = "0.0.2"
   s.platform          = Gem::Platform::RUBY
   s.authors           = ["Jason Langenauer"]
   s.email             = ["jason@jasonlangenauer.com"]

--- a/gem.gemspec
+++ b/gem.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.name              = "rails_admin_map_field"
   s.version           = "0.0.2"
   s.platform          = Gem::Platform::RUBY
-  s.authors           = ["Jason Langenauer"]
-  s.email             = ["jason@jasonlangenauer.com"]
+  s.authors           = ["Jason Langenauer","Jules Laplace"]
+  s.email             = ["jason@jasonlangenauer.com","jules@okfoc.us"]
   s.homepage          = "http://github.com/jasonl/"
   s.summary           = "Adds a map field using the Google Maps API to rails_admin"
   s.description       = "A map field for RailsAdmin that can be used to manipulate a latitude/longitude field pair"

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -5,19 +5,19 @@ module RailsAdmin::Config::Fields::Types
     # THe name of the corresponding longitude field to match the latitude field
     # in this object.
     register_instance_option(:longitude_field) do
-      :longitude
+      "longitude"
     end
 
     register_instance_option(:address_field) do
-      :address
+      "address"
     end
 
     register_instance_option(:city_field) do
-      :city
+      "city"
     end
 
     register_instance_option(:state_field) do
-      :state
+      "state"
     end
 
     register_instance_option(:partial) do
@@ -46,15 +46,27 @@ module RailsAdmin::Config::Fields::Types
     end
 
     def dom_name
-      @dom_name ||= "#{bindings[:form].object_name}_#{@name}_#{@longitude_field}"
+      "#{bindings[:form].object_name}_#{@name}_#{longitude_field}"
     end
 
     def latitude_dom_name
-      @lat_dom_name ||= "#{bindings[:form].object_name}_#{@name}"
+      "#{bindings[:form].object_name}_#{@name}"
     end
 
     def longitude_dom_name
-      @lon_dom_name ||= "#{bindings[:form].object_name}_#{@longitude_field}"
+      "#{bindings[:form].object_name}_#{longitude_field}"
+    end
+
+    def address_dom_name
+      "#{bindings[:form].object_name}_#{address_field}"
+    end
+
+    def city_dom_name
+      "#{bindings[:form].object_name}_#{city_field}"
+    end
+
+    def state_dom_name
+      "#{bindings[:form].object_name}_#{state_field}"
     end
   end
 end

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -46,27 +46,27 @@ module RailsAdmin::Config::Fields::Types
     end
 
     def dom_name
-      @dom_name ||= "#{bindings[:form].object_name}_#{@name}_#{@longitude_field}"
+      "#{bindings[:form].object_name}_#{@name}_#{longitude_field}"
     end
 
     def latitude_dom_name
-      @lat_dom_name ||= "#{bindings[:form].object_name}_#{@name}"
+      "#{bindings[:form].object_name}_#{@name}"
     end
 
     def longitude_dom_name
-      @lon_dom_name ||= "#{bindings[:form].object_name}_#{@longitude_field}"
+      "#{bindings[:form].object_name}_#{longitude_field}"
     end
 
     def address_dom_name
-      @address_dom_name ||= "#{bindings[:form].object_name}_#{@address_field}"
+      "#{bindings[:form].object_name}_#{address_field}"
     end
 
     def city_dom_name
-      @city_dom_name ||= "#{bindings[:form].object_name}_#{@city_field}"
+      "#{bindings[:form].object_name}_#{city_field}"
     end
 
     def state_dom_name
-      @state_dom_name ||= "#{bindings[:form].object_name}_#{@state_field}"
+      "#{bindings[:form].object_name}_#{state_field}"
     end
   end
 end

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -32,12 +32,12 @@ module RailsAdmin::Config::Fields::Types
     # Latitude value to display in the map if the latitude attribute is nil
     # (Otherwise the location defaults to (0,0) which is in the Gulf of Guinea
     register_instance_option(:default_latitude) do
-      51.5 # Latitude of London, United Kingdom
+      40.711417 # Latitude of Jersey City, NJ
     end
 
     # Longitude value to display if the longitude attribute is nil
     register_instance_option(:default_longitude) do
-      -0.126 # Longitude of London, United Kingdom
+      74.0647 # Longitude of Jersey City, NJ
     end
 
     # Default zoom level of the map

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -56,5 +56,17 @@ module RailsAdmin::Config::Fields::Types
     def longitude_dom_name
       @lon_dom_name ||= "#{bindings[:form].object_name}_#{@longitude_field}"
     end
+
+    def address_dom_name
+      @address_dom_name ||= "#{bindings[:form].object_name}_#{@address_field}"
+    end
+
+    def city_dom_name
+      @city_dom_name ||= "#{bindings[:form].object_name}_#{@city_field}"
+    end
+
+    def state_dom_name
+      @state_dom_name ||= "#{bindings[:form].object_name}_#{@state_field}"
+    end
   end
 end

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -8,6 +8,18 @@ module RailsAdmin::Config::Fields::Types
       :longitude
     end
 
+    register_instance_option(:address_field) do
+      :address
+    end
+
+    register_instance_option(:city_field) do
+      :city
+    end
+
+    register_instance_option(:state_field) do
+      :state
+    end
+
     register_instance_option(:partial) do
       :form_map
     end

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -5,19 +5,19 @@ module RailsAdmin::Config::Fields::Types
     # THe name of the corresponding longitude field to match the latitude field
     # in this object.
     register_instance_option(:longitude_field) do
-      :longitude
+      "longitude"
     end
 
     register_instance_option(:address_field) do
-      :address
+      "address"
     end
 
     register_instance_option(:city_field) do
-      :city
+      "city"
     end
 
     register_instance_option(:state_field) do
-      :state
+      "state"
     end
 
     register_instance_option(:partial) do


### PR DESCRIPTION
Greetings,

I have modified your map field plugin for Rails Admin to geocode a lat/lng pair on the fly based on address fields.  I also fixed some things which weren't working for me in the Ruby module -- the longitude parameter was not being passed through to the template at all. It appeared to be a global issue, but it's working now on my end.

I admit, this does change the functionality compared to your version, so let me know how you'd like to proceed since I think really is useful, especially for applications with heavy maps integration (like the one I'm working on..).

I noticed your note on rebasing inconsequential commits on a previous fork, and have attempted to clean up my commits preemptively.

Best wishes and thanks for writing this,
Jules Laplace
