### PR TITLE
Put Map Width and Height inside configuration

### DIFF
--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -5,6 +5,7 @@
     function init_map_field(){
     jQuery(function(){
       var marker = null;
+
       var latlng = new google.maps.LatLng(#{form.object.send(field.name) || field.default_latitude}, #{form.object.send(field.longitude_field) || field.default_longitude});
 
       var myOptions = {
@@ -21,6 +22,12 @@
         position: new google.maps.LatLng(#{form.object.send(field.name)},#{form.object.send(field.longitude_field)}),
         map: map
       });
+      google.maps.event.addListener(marker, 'click', function(e) {
+        marker.setMap(null);
+        jQuery("##{field.latitude_dom_name}").val(null);
+        jQuery("##{field.longitude_dom_name}").val(null);
+      });
+
 
   :plain
       google.maps.event.addListener(map, 'click', function(e) {
@@ -30,11 +37,17 @@
       function updateLocation(location) {
         if(marker) {
           marker.setPosition(location);
+          marker.setMap(map);
         } else {
           marker = new google.maps.Marker({
             position: location,
             map: map
           });
+        google.maps.event.addListener(marker, 'click', function(e) {
+          marker.setMap(null);
+          jQuery("##{field.latitude_dom_name}").val(null);
+          jQuery("##{field.longitude_dom_name}").val(null);
+        });
         }
 
         map.setCenter(location);

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -43,6 +43,6 @@
       }
 
     })};
-%div.ramf-map-container{:id => field.dom_name, :style => "width:300px;height:200px"}
+%div.ramf-map-container{:id => field.dom_name, :style => "width:#{field.map_width};height:#{field.map_height}"}
 = form.send :hidden_field, field.name, :id => field.latitude_dom_name
 = form.send :hidden_field, field.longitude_field, :id => field.longitude_dom_name

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -37,6 +37,17 @@ module RailsAdmin::Config::Fields::Types
       8
     end
 
+    # Google Maps API Key - optional
+    register_instance_option(:map_width) do
+      "300px"
+    end
+
+    # Google Maps API Key - optional
+    register_instance_option(:map_height) do
+      "200px"
+    end
+
+
     def dom_name
       @dom_name ||= "#{bindings[:form].object_name}_#{@name}_#{longitude_field}"
     end


### PR DESCRIPTION
Hi !!

thanks for your plugin. 

Upon a customer request for a bigger map I decided to put width and height of map container inside configuration block.

Bye 
Giacomo

UPDATE: the delete pin commit, delete pin from map after clicking on it. Now there's no way to delete pin.
