### PR TITLE
-Reordering the div position to be in the beginning of the file before t...

### DIFF
--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -1,3 +1,7 @@
+%div.ramf-map-container{:id => field.dom_name, :style => "width:300px;height:200px"}
+= form.send :hidden_field, field.name, :id => field.latitude_dom_name
+= form.send :hidden_field, field.longitude_field, :id => field.longitude_dom_name
+
 = javascript_include_tag ("http://maps.googleapis.com/maps/api/js?key=#{field.google_api_key}&sensor=false&callback=init_map_field")
 
 = javascript_tag do
@@ -43,6 +47,3 @@
       }
 
     })};
-%div.ramf-map-container{:id => field.dom_name, :style => "width:300px;height:200px"}
-= form.send :hidden_field, field.name, :id => field.latitude_dom_name
-= form.send :hidden_field, field.longitude_field, :id => field.longitude_dom_name


### PR DESCRIPTION
Using the map field raised an error in the first load of the partial "google is not defined".
i had to refresh the page to get the map shown as the js files from google are already loaded,
I had to modify the app / views / rails_admin / main / _form_map.html.haml to place the div element

``` ruby
%div.ramf-map-container{:id => field.dom_name, :style => "width:300px;height:200px"}
= form.send :hidden_field, field.name, :id => field.latitude_dom_name
= form.send :hidden_field, field.longitude_field, :id => field.longitude_dom_name
```

to the beginning of the file before loading the js
