### PR TITLE
Add numerous functions from 3-4 forks (add lat and lon live textfields, and map resizing in config. Smaller bugfixes etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+Rails Admin Map Field:
+=====
+
+rails_admin_map_field is a gem that works with sferik's **rails_admin** (https://github.com/sferik/rails_admin) to provide an easy to use Google Maps interface for displaying and setting geographic co-ordinates in a model.
+
+Where a latitude and longitude is set on the model(or below map), it is indicated by a marker shown on a Google map centered at the marker. The administrator is expected to also store address, city, and state fields.  As these fields are filled in, the Maps API is used to geocode the address in order to determine the latitude and longitude of the map marker, which is updated on the fly.
+
+Usage
+=====
+
+*New features:
+- map resizing in config
+```
+field :lat, :map do
+  map_width '600px'
+  map_height '400px'
+end
+
+- adds :latitude, :longitude live text fields below map
+
+
+rails_admin_map_field expects that the model will have two attributes, one for latitude and one for longitude of the point represented. To enable rails_admin_map_field, add the following to your `Gemfile`:
+
+```ruby
+gem "rails_admin_map_field", :git => "git://github.com/beyondthestory/rails_admin_map_field.git"
+```
+
+Then, add in your `config/initializers/rails_admin.rb` initializer:
+
+```ruby
+RailsAdmin.config do |config|
+  config.model User do
+    edit do
+      field :latitude, :map
+    end
+  end
+end
+```
+
+**Note**: The field which is set as a map-type field must be the latitude field, not the longitude. By default, rails_admin_map_field will guess that the longitude field is called "longitude".
+
+Configuration
+=============
+
+For different configurations, rails_admin_map_field can be configured with the following:
+
+- `longitude_field` - the name of the longitude field that forms the the co-ordinate with the latitude field specified. Defaults to "longitude"
+- `address_field` - the name of the address field. Defaults to "address"
+- `city_field` - the name of the city field. Defaults to "city"
+- `state_field` - the name of the state field. Defaults to "state"
+- `google_api_key` - if you use a Google Maps API Key, it can be specified here.
+- `default_latitude` - the latitude to center the map shown on if the latitude field is blank. Defaults to 51.5, the latitude of London, UK.
+- `default_longitude` - the longitude used if the longitude field is blank. Defaults to -0.126, the longitude of London, UK.
+- map_width - map width, eg: '400px'
+- map_height - map height
+
+
+A more complicated configuration example:
+
+```ruby
+RailsAdmin.config do |config|
+  config.model Point do
+    edit do
+      field :lat, :map do
+        longitude_field :lon
+        google_api_key "a1b2c3d4e5f6deadbeef"
+        default_latitude -34.0  # Sydney, Australia
+        default_longitude 151.0
+      end
+    end
+  end
+end
+```
+
+LICENSE
+=======
+rails_admin_map_field is licensed under the MIT license.
+
+Copyright (C) 2011 by Jason Langenauer, Jules Laplace, Valentin
+Ballestrino, Bartlomiej Skwira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -1,48 +1,93 @@
-= javascript_include_tag ("http://maps.googleapis.com/maps/api/js?key=#{field.google_api_key}&sensor=false")
-= #require_asset('ramf.js')
-
 = javascript_tag do
   :plain
-    jQuery(function(){
-      var marker = null;
-      var latlng = new google.maps.LatLng(#{form.object.send(field.name) || field.default_latitude}, #{form.object.send(field.longitude_field) || field.default_longitude});
+    function initMapField() {
+      jQuery(function(){
+        var marker = null;
+        var latlng = new google.maps.LatLng(#{form.object.send(field.name) || field.default_latitude}, #{form.object.send(field.longitude_field) || field.default_longitude});
 
-      var myOptions = {
-        zoom: 8,
-        center: latlng,
-        mapTypeId: google.maps.MapTypeId.ROADMAP
-      };
+        var myOptions = {
+          zoom: #{field.default_zoom_level},
+          center: latlng,
+          mapTypeId: google.maps.MapTypeId.ROADMAP
+        };
 
-      var map = new google.maps.Map(document.getElementById("#{field.dom_name}"), myOptions);
+        var map = new google.maps.Map(document.getElementById("#{field.dom_name}"), myOptions);
+        var geocoder = new google.maps.Geocoder();
+
+        var map = new google.maps.Map(document.getElementById("#{field.dom_name}"), myOptions);
+        var geocoder = new google.maps.Geocoder();
 
   - if form.object.send(field.name) && form.object.send(field.longitude_field)
     :plain
-      marker = new google.maps.Marker({
-        position: new google.maps.LatLng(#{form.object.send(field.name)},#{form.object.send(field.longitude_field)}),
-        map: map
-      });
+        marker = new google.maps.Marker({
+          position: new google.maps.LatLng(#{form.object.send(field.name)},#{form.object.send(field.longitude_field)}),
+          map: map
+        });
 
   :plain
-      google.maps.event.addListener(map, 'click', function(e) {
-        updateLocation(e.latLng);
-      });
+        var old_address = "";
+        function processAddress() {
+          // geocode based on this location
+          var address = $("##{field.address_dom_name}").val(),
+          city = $("##{field.city_dom_name}").val() || "",
+          state = $("##{field.state_dom_name}").val() || "",
+          address_string = "",
+          changed = false;
 
-      function updateLocation(location) {
-        if(marker) {
-          marker.setPosition(location);
-        } else {
-          marker = new google.maps.Marker({
-            position: location,
-            map: map
+          if (address.length === 0)
+            return;
+
+          address_string = address;
+          if(city) address_string += ", " + city;
+          if(state) address_string += ", " + state;
+
+          if ((address === undefined) || (address.length === 0))
+            return;
+
+          old_address = address_string;
+
+          geocoder.geocode({ 'address': address_string }, function(results, status){
+            if (! results || results.length === 0 || status !== "OK") return;
+
+            var location = results[0].geometry.location;
+            updateLocation(location);
           });
+        };
+
+        google.maps.event.addListener(map, 'click', function(e) {
+          updateLocation(e.latLng);
+        });
+
+        function updateLocation(location) {
+          if(marker) {
+            marker.setPosition(location);
+          } else {
+            marker = new google.maps.Marker({
+              position: location,
+              map: map
+            });
+          }
+
+          map.setCenter(location);
+          jQuery("##{field.latitude_dom_name}").val(location.lat());
+          jQuery("##{field.longitude_dom_name}").val(location.lng());
         }
 
-        map.setCenter(location);
-        jQuery("##{field.latitude_dom_name}").val(location.lat());
-        jQuery("##{field.longitude_dom_name}").val(location.lng());
-      }
+        jQuery("##{field.address_dom_name},##{field.city_dom_name},##{field.state_dom_name}").bind("blur", processAddress);
+        processAddress();
 
-    });
-%div.ramf-map-container{:id => field.dom_name, :style => "width:300px;height:200px"}
-= form.send :hidden_field, field.name, :id => field.latitude_dom_name
-= form.send :hidden_field, field.longitude_field, :id => field.longitude_dom_name
+      });
+    }
+
+= javascript_include_tag ("http://maps.googleapis.com/maps/api/js?key=#{field.google_api_key}&sensor=false&callback=initMapField")
+
+%div.ramf-map-container{:id => field.dom_name, :style => "width:#{field.map_width};height:#{field.map_height}"}
+%div.control-group
+  = form.send :label, field.name, :class => "control-label"
+  %div.controls
+    = form.send :text_field, field.name, :id => field.latitude_dom_name
+
+%div.control-group
+  = form.send :label, field.longitude_field, :class => "control-label"
+  %div.controls
+    = form.send :text_field, field.longitude_field, :id => field.longitude_dom_name

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -1,1 +1,93 @@
-%h2 Map Field Helper
+= javascript_tag do
+  :plain
+    function initMapField() {
+      jQuery(function(){
+        var marker = null;
+        var latlng = new google.maps.LatLng(#{form.object.send(field.name) || field.default_latitude}, #{form.object.send(field.longitude_field) || field.default_longitude});
+
+        var myOptions = {
+          zoom: #{field.default_zoom_level},
+          center: latlng,
+          mapTypeId: google.maps.MapTypeId.ROADMAP
+        };
+
+        var map = new google.maps.Map(document.getElementById("#{field.dom_name}"), myOptions);
+        var geocoder = new google.maps.Geocoder();
+
+        var map = new google.maps.Map(document.getElementById("#{field.dom_name}"), myOptions);
+        var geocoder = new google.maps.Geocoder();
+
+  - if form.object.send(field.name) && form.object.send(field.longitude_field)
+    :plain
+        marker = new google.maps.Marker({
+          position: new google.maps.LatLng(#{form.object.send(field.name)},#{form.object.send(field.longitude_field)}),
+          map: map
+        });
+
+  :plain
+        var old_address = "";
+        function processAddress() {
+          // geocode based on this location
+          var address = $("##{field.address_dom_name}").val(),
+          city = $("##{field.city_dom_name}").val() || "",
+          state = $("##{field.state_dom_name}").val() || "",
+          address_string = "",
+          changed = false;
+
+          if (address.length === 0)
+            return;
+
+          address_string = address;
+          if(city) address_string += ", " + city;
+          if(state) address_string += ", " + state;
+
+          if ((address === undefined) || (address.length === 0))
+            return;
+
+          old_address = address_string;
+
+          geocoder.geocode({ 'address': address_string }, function(results, status){
+            if (! results || results.length === 0 || status !== "OK") return;
+
+            var location = results[0].geometry.location;
+            updateLocation(location);
+          });
+        };
+
+        google.maps.event.addListener(map, 'click', function(e) {
+          updateLocation(e.latLng);
+        });
+
+        function updateLocation(location) {
+          if(marker) {
+            marker.setPosition(location);
+          } else {
+            marker = new google.maps.Marker({
+              position: location,
+              map: map
+            });
+          }
+
+          map.setCenter(location);
+          jQuery("##{field.latitude_dom_name}").val(location.lat());
+          jQuery("##{field.longitude_dom_name}").val(location.lng());
+        }
+
+        jQuery("##{field.address_dom_name},##{field.city_dom_name},##{field.state_dom_name}").bind("blur", processAddress);
+        processAddress();
+
+      });
+    }
+
+= javascript_include_tag ("http://maps.googleapis.com/maps/api/js?key=#{field.google_api_key}&sensor=false&callback=initMapField")
+
+%div.ramf-map-container{:id => field.dom_name, :style => "width:#{field.map_width};height:#{field.map_height}"}
+%div.control-group
+  = form.send :label, field.name, :class => "control-label"
+  %div.controls
+    = form.send :text_field, field.name, :id => field.latitude_dom_name
+
+%div.control-group
+  = form.send :label, field.longitude_field, :class => "control-label"
+  %div.controls
+    = form.send :text_field, field.longitude_field, :id => field.longitude_dom_name

--- a/gem.gemspec
+++ b/gem.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
 
 
   s.name              = "rails_admin_map_field"
-  s.version           = "0.0.1"
+  s.version           = "0.0.2"
   s.platform          = Gem::Platform::RUBY
-  s.authors           = ["Jason Langenauer"]
-  s.email             = ["jason@jasonlangenauer.com"]
+  s.authors           = ["Jason Langenauer","Jules Laplace"]
+  s.email             = ["jason@jasonlangenauer.com","jules@okfoc.us"]
   s.homepage          = "http://github.com/jasonl/"
   s.summary           = "Adds a map field using the Google Maps API to rails_admin"
   s.description       = "A map field for RailsAdmin that can be used to manipulate a latitude/longitude field pair"

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -2,10 +2,26 @@ module RailsAdmin::Config::Fields::Types
   class Map < RailsAdmin::Config::Fields::Base
     RailsAdmin::Config::Fields::Types::register(:map, self)
 
+    def allowed_methods
+      [@name, longitude_field]
+    end
+
     # THe name of the corresponding longitude field to match the latitude field
     # in this object.
     register_instance_option(:longitude_field) do
-      :longitude
+      "longitude"
+    end
+
+    register_instance_option(:address_field) do
+      "address"
+    end
+
+    register_instance_option(:city_field) do
+      "city"
+    end
+
+    register_instance_option(:state_field) do
+      "state"
     end
 
     register_instance_option(:partial) do
@@ -20,24 +36,52 @@ module RailsAdmin::Config::Fields::Types
     # Latitude value to display in the map if the latitude attribute is nil
     # (Otherwise the location defaults to (0,0) which is in the Gulf of Guinea
     register_instance_option(:default_latitude) do
-      51.5 # Latitude of London, United Kingdom
+      40.711417 # Latitude of Jersey City, NJ
     end
 
     # Longitude value to display if the longitude attribute is nil
     register_instance_option(:default_longitude) do
-      -0.126 # Longitude of London, United Kingdom
+      74.0647 # Longitude of Jersey City, NJ
     end
 
+    # Default zoom level of the map
+    register_instance_option(:default_zoom_level) do
+      8
+    end
+
+    # Google Maps API Key - optional
+    register_instance_option(:map_width) do
+      "300px"
+    end
+
+    # Google Maps API Key - optional
+    register_instance_option(:map_height) do
+      "200px"
+    end
+
+
     def dom_name
-      @dom_name ||= "#{bindings[:form].object_name}_#{@name}_#{@longitude_field}"
+      @dom_name ||= "#{bindings[:form].object_name}_#{@name}_#{longitude_field}"
     end
 
     def latitude_dom_name
-      @lat_dom_name ||= "#{bindings[:form].object_name}_#{@name}"
+      "#{bindings[:form].object_name}_#{@name}"
     end
 
     def longitude_dom_name
-      @lon_dom_name ||= "#{bindings[:form].object_name}_#{@longitude_field}"
+      @lon_dom_name ||= "#{bindings[:form].object_name}_#{longitude_field}"
+    end
+
+    def address_dom_name
+      "#{bindings[:form].object_name}_#{address_field}"
+    end
+
+    def city_dom_name
+      "#{bindings[:form].object_name}_#{city_field}"
+    end
+
+    def state_dom_name
+      "#{bindings[:form].object_name}_#{state_field}"
     end
   end
 end

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -2,12 +2,86 @@ module RailsAdmin::Config::Fields::Types
   class Map < RailsAdmin::Config::Fields::Base
     RailsAdmin::Config::Fields::Types::register(:map, self)
 
+    def allowed_methods
+      [@name, longitude_field]
+    end
+
+    # THe name of the corresponding longitude field to match the latitude field
+    # in this object.
     register_instance_option(:longitude_field) do
-      :longitude
+      "longitude"
+    end
+
+    register_instance_option(:address_field) do
+      "address"
+    end
+
+    register_instance_option(:city_field) do
+      "city"
+    end
+
+    register_instance_option(:state_field) do
+      "state"
     end
 
     register_instance_option(:partial) do
       :form_map
+    end
+
+    # Google Maps API Key - optional
+    register_instance_option(:google_api_key) do
+      nil
+    end
+
+    # Latitude value to display in the map if the latitude attribute is nil
+    # (Otherwise the location defaults to (0,0) which is in the Gulf of Guinea
+    register_instance_option(:default_latitude) do
+      40.711417 # Latitude of Jersey City, NJ
+    end
+
+    # Longitude value to display if the longitude attribute is nil
+    register_instance_option(:default_longitude) do
+      74.0647 # Longitude of Jersey City, NJ
+    end
+
+    # Default zoom level of the map
+    register_instance_option(:default_zoom_level) do
+      8
+    end
+
+    # Google Maps API Key - optional
+    register_instance_option(:map_width) do
+      "300px"
+    end
+
+    # Google Maps API Key - optional
+    register_instance_option(:map_height) do
+      "200px"
+    end
+
+
+    def dom_name
+      @dom_name ||= "#{bindings[:form].object_name}_#{@name}_#{longitude_field}"
+    end
+
+    def latitude_dom_name
+      "#{bindings[:form].object_name}_#{@name}"
+    end
+
+    def longitude_dom_name
+      @lon_dom_name ||= "#{bindings[:form].object_name}_#{longitude_field}"
+    end
+
+    def address_dom_name
+      "#{bindings[:form].object_name}_#{address_field}"
+    end
+
+    def city_dom_name
+      "#{bindings[:form].object_name}_#{city_field}"
+    end
+
+    def state_dom_name
+      "#{bindings[:form].object_name}_#{state_field}"
     end
   end
 end


### PR DESCRIPTION
As a response to a request in https://github.com/beyondthestory/rails_admin_map_field/pull/7 - this is about 30 commits made by Jules Laplace, vala, Jason Langenauer, Bartlomiej Skwira all rebased/squashed. Adds stuff like:
- adding fields in lib
- geocode the address and use that to set the lat/lng
- make using country and state fields optional
- add map_width and map_height, and run map code in gmap load callback
- lat and lon live textfields 
- map resizing in config
- smaller bugfixes

Rebase against current master was too tricky for me, there were too many changes for me to merge it correctly. Merge at your own risk :P
