### PR TITLE
Adding more map options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ For different configurations, rails_admin_map_field can be configured with the f
 - `google_api_key` - if you use a Google Maps API Key, it can be specified here.
 - `default_latitude` - the latitude to center the map shown on if the latitude field is blank. Defaults to 51.5, the latitude of London, UK.
 - `default_longitude` - the longitude used if the longitude field is blank. Defaults to -0.126, the longitude of London, UK.
+- `draggable` - when to enable draggable map. Default true.
+- `scrollwheel` - when to enable scrolling map with mouse wheel. Default true.
+- `zoom_control` - when to enable zoom control on top of map. Default true.
+- `street_view_control` - when to enable street_view option. Default true.
+- `fixed_marker` - when to disable relocating the marker (like read_only true). Default false.
+- `disable_double_click_zoom` - when to disable zoom with mouse double click. Default false.
+- `width` - map width in px. Default 300.
+- `height` - map height in px. Default 200.
 
 A more complicated configuration example:
 
@@ -49,6 +57,7 @@ RailsAdmin.config do |config|
         google_api_key "a1b2c3d4e5f6deadbeef"
         default_latitude -34.0  # Sydney, Australia
         default_longitude 151.0
+        zoom_control false
       end
     end
   end

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -10,6 +10,12 @@
       var myOptions = {
         zoom: #{field.default_zoom_level},
         center: latlng,
+        draggable: #{field.draggable},
+        scrollwheel: #{field.scrollwheel},
+        zoomControl: #{field.zoom_control},
+        disableDoubleClickZoom: #{field.disable_double_click_zoom}
+        streetViewControl: #{field.street_view_control},
+        center: latlng,
         mapTypeId: google.maps.MapTypeId.ROADMAP
       };
 
@@ -22,27 +28,28 @@
         map: map
       });
 
-  :plain
+  - unless field.fixed_marker
+    :plain
       google.maps.event.addListener(map, 'click', function(e) {
-        updateLocation(e.latLng);
-      });
+          updateLocation(e.latLng);
+        });
 
-      function updateLocation(location) {
-        if(marker) {
-          marker.setPosition(location);
-        } else {
-          marker = new google.maps.Marker({
-            position: location,
-            map: map
-          });
+        function updateLocation(location) {
+          if(marker) {
+            marker.setPosition(location);
+          } else {
+            marker = new google.maps.Marker({
+              position: location,
+              map: map
+            });
+          }
+
+          map.setCenter(location);
+          jQuery("##{field.latitude_dom_name}").val(location.lat());
+          jQuery("##{field.longitude_dom_name}").val(location.lng());
         }
-
-        map.setCenter(location);
-        jQuery("##{field.latitude_dom_name}").val(location.lat());
-        jQuery("##{field.longitude_dom_name}").val(location.lng());
-      }
-
-    })};
-%div.ramf-map-container{:id => field.dom_name, :style => "width:300px;height:200px"}
+  :plain
+      })};
+%div.ramf-map-container{:id => field.dom_name, :style => "width:#{field.width}px;height:#{field.height}px"}
 = form.send :hidden_field, field.name, :id => field.latitude_dom_name
 = form.send :hidden_field, field.longitude_field, :id => field.longitude_dom_name

--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -13,7 +13,7 @@
         draggable: #{field.draggable},
         scrollwheel: #{field.scrollwheel},
         zoomControl: #{field.zoom_control},
-        disableDoubleClickZoom: #{field.disable_double_click_zoom}
+        disableDoubleClickZoom: #{field.disable_double_click_zoom},
         streetViewControl: #{field.street_view_control},
         center: latlng,
         mapTypeId: google.maps.MapTypeId.ROADMAP

--- a/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
+++ b/lib/rails_admin_map_field/rails_admin/config/fields/types/map.rb
@@ -16,6 +16,38 @@ module RailsAdmin::Config::Fields::Types
       :form_map
     end
 
+    register_instance_option(:draggable) do
+      true
+    end
+
+    register_instance_option(:scrollwheel) do
+      true
+    end
+
+    register_instance_option(:zoom_control) do
+      true
+    end
+
+    register_instance_option(:street_view_control) do
+      true
+    end
+
+    register_instance_option(:fixed_marker) do
+      false
+    end
+
+    register_instance_option(:disable_double_click_zoom) do
+      false
+    end
+
+    register_instance_option(:width) do
+      300
+    end
+
+    register_instance_option(:height) do
+      200
+    end
+
     # Google Maps API Key - optional
     register_instance_option(:google_api_key) do
       nil


### PR DESCRIPTION
Adding field options for adjust width and height.
Adding google map api options
- Draggable
- Scroll wheel zoom
- Zoom control
- Street view control
- Fixed marker (aka read_only marker)
- Disable double click zoom
