### PR TITLE
removed sensor parameter in googlemaps js link, moved javascript incl…

### DIFF
--- a/app/views/rails_admin/main/_form_map.html.haml
+++ b/app/views/rails_admin/main/_form_map.html.haml
@@ -1,5 +1,3 @@
-= javascript_include_tag ("http://maps.googleapis.com/maps/api/js?key=#{field.google_api_key}&sensor=false&callback=init_map_field")
-
 = javascript_tag do
   :plain
     function init_map_field(){
@@ -43,6 +41,9 @@
       }
 
     })};
+
+= javascript_include_tag ("http://maps.googleapis.com/maps/api/js?key=#{field.google_api_key}&callback=init_map_field")
+
 %div.ramf-map-container{:id => field.dom_name, :style => "width:300px;height:200px"}
 = form.send :hidden_field, field.name, :id => field.latitude_dom_name
 = form.send :hidden_field, field.longitude_field, :id => field.longitude_dom_name


### PR DESCRIPTION
I noticed Google Maps deprecated the usage of "sensor" parameter inhibiting the initialization of the map if present, so i removed it:
https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required

Sometimes I've received initialization errors apparently because init_map_field definition was invoked too soon by google maps script, before it has been defined so i moved gmap script include tag after it.

Thanks,
Davide